### PR TITLE
Honour `mail_header_only` also if combined filetype includes `mail`

### DIFF
--- a/lua/cmp_lbdb/init.lua
+++ b/lua/cmp_lbdb/init.lua
@@ -52,7 +52,7 @@ function source.complete(self, params, callback)
         items = cmp_contacts
       })
     else
-      if not (vim.bo.filetype == 'mail' and opts.mail_header_only) then
+      if not (utils.has_filetype({ "mail" }, vim.bo.filetype) and opts.mail_header_only) then
         callback({
           items = full_set
         })


### PR DESCRIPTION
Commit c6f0c43 fixed #13, but a little further down, there is another check of the filetype that needs to be done similarly. This commit does that. Without it, `mail_header_only` didn't have the desired effect, as the inverted filetype check was always true.